### PR TITLE
fix(runner): reconnect VMI watch on stream closure

### DIFF
--- a/docs/how-to-guides/configure-timeouts.md
+++ b/docs/how-to-guides/configure-timeouts.md
@@ -49,6 +49,18 @@ while the terminal `Succeeded`/`Failed` phase ends the wait.
 The wait timeout (`KAR_WAIT_TIMEOUT`) therefore needs to cover the entire
 expected job duration, not just provisioning time.
 
+## Watch stream reconnection
+
+Kubernetes API watch streams can close during long-running jobs,
+even when the VMI is still running correctly.
+When this happens,
+the runner checks the current VMI phase and opens a new watch stream.
+This avoids treating an API-server watch timeout as a job failure.
+
+The reconnect loop still uses `KAR_WAIT_TIMEOUT` as the total wait budget.
+If the VMI never reaches `Succeeded` or `Failed` before that timeout expires,
+the runner exits with a wait-timeout error.
+
 ## Steps to configure `KAR_WAIT_TIMEOUT`
 
 ### 1. Set the environment variable

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ below to navigate through the different sections.
 
 - [Enable Telemetry](how-to-guides/enable-telemetry.md): Detailed steps to
   enable and configure telemetry for better observability.
+- [Configure Runner Timeouts](how-to-guides/configure-timeouts.md): Configure
+  wait and cleanup timeouts for VM-backed jobs.
 - [Set Up Testbed](how-to-guides/setup-testbed.md): Instructions to create a
   local test environment for validation and development.
 

--- a/internal/runner.go
+++ b/internal/runner.go
@@ -30,6 +30,7 @@ import (
 	k8scorev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	k8swatch "k8s.io/apimachinery/pkg/watch"
 	v1 "kubevirt.io/api/core/v1"
@@ -162,32 +163,112 @@ func (rc *KubevirtRunner) WaitForVirtualMachineInstance(ctx context.Context) err
 	log.Printf("Watching %s Virtual Machine Instance\n", vmiName)
 	span.SetAttributes(attribute.String("vmiName", vmiName))
 
-	watch, err := rc.virtClient.VirtualMachineInstance(rc.namespace).Watch(ctx, k8smetav1.ListOptions{})
+	var currentStatus v1.VirtualMachineInstancePhase
+	vmiInterface := rc.virtClient.VirtualMachineInstance(rc.namespace)
+
+	for {
+		done, resourceVersion, terminalErr := rc.refreshVMIStatus(ctx, span, vmiInterface, vmiName, &currentStatus)
+		if done {
+			return terminalErr
+		}
+
+		watch, watchErr := vmiInterface.Watch(ctx, watchOptions(vmiName, resourceVersion))
+		if watchErr != nil {
+			span.RecordError(watchErr)
+
+			return fmt.Errorf("failed to watch the virtual machine instance: %w", watchErr)
+		}
+
+		done, watchResultErr := watchVMIEvents(ctx, span, watch, vmiName, &currentStatus)
+		watch.Stop()
+		if done {
+			return watchResultErr
+		}
+
+		if watchResultErr == nil {
+			log.Printf("Watch stream closed for %s Virtual Machine Instance; reconnecting\n", vmiName)
+			span.AddEvent("watch_reconnect", trace.WithAttributes(
+				attribute.String("reason", errWatchChannelClosed.Error()),
+			))
+
+			if ctx.Err() != nil {
+				return errWaitTimeout
+			}
+
+			continue
+		}
+
+		return watchResultErr
+	}
+}
+
+func (rc *KubevirtRunner) refreshVMIStatus(
+	ctx context.Context,
+	span trace.Span,
+	vmiInterface kubecli.VirtualMachineInstanceInterface,
+	vmiName string,
+	currentStatus *v1.VirtualMachineInstancePhase,
+) (bool, string, error) {
+	if ctx.Err() != nil {
+		return true, "", errWaitTimeout
+	}
+
+	vmi, err := vmiInterface.Get(ctx, vmiName, k8smetav1.GetOptions{})
 	if err != nil {
+		if ctx.Err() != nil {
+			return true, "", errWaitTimeout
+		}
+
 		span.RecordError(err)
 
-		return fmt.Errorf("failed to watch the virtual machine instance: %w", err)
+		return true, "", fmt.Errorf("failed to get the virtual machine instance %q: %w", vmiName, err)
 	}
-	defer watch.Stop()
 
-	var currentStatus v1.VirtualMachineInstancePhase
+	if vmi.Status.Phase == v1.Running && isVMIReady(vmi) {
+		utils.GetLogger().Printf("%s is Running and Ready\n", vmiName)
+		span.SetAttributes(attribute.String("phase", "Running+Ready"))
+	}
 
+	if vmi.Status.Phase == *currentStatus {
+		return false, vmi.ResourceVersion, nil
+	}
+
+	done, err := handleVMIPhase(span, vmiName, vmi.Status.Phase)
+	*currentStatus = vmi.Status.Phase
+
+	return done, vmi.ResourceVersion, err
+}
+
+func watchOptions(vmiName, resourceVersion string) k8smetav1.ListOptions {
+	return k8smetav1.ListOptions{
+		FieldSelector:   fields.OneTermEqualSelector("metadata.name", vmiName).String(),
+		ResourceVersion: resourceVersion,
+	}
+}
+
+func watchVMIEvents(
+	ctx context.Context,
+	span trace.Span,
+	watch k8swatch.Interface,
+	vmiName string,
+	currentStatus *v1.VirtualMachineInstancePhase,
+) (bool, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return errWaitTimeout
+			return true, errWaitTimeout
 		case event, watchOpen := <-watch.ResultChan():
 			if !watchOpen {
-				return errWatchChannelClosed
+				return false, nil
 			}
 
-			done, skip, err := handleWatchEvent(span, vmiName, event, &currentStatus)
+			done, skip, err := handleWatchEvent(span, vmiName, event, currentStatus)
 			if skip {
 				continue
 			}
 
 			if done {
-				return err
+				return true, err
 			}
 		}
 	}

--- a/internal/runner_test.go
+++ b/internal/runner_test.go
@@ -25,7 +25,9 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	k8sv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	v1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
@@ -66,11 +68,21 @@ var _ = Describe("Runner", func() {
 		runner.CancelAppContext()
 	})
 
-	startVMIWatcher := func(karRunner runner.Runner) (*watch.FakeWatcher, chan error) {
-		fakeWatcher := watch.NewFake()
-
+	startVMIWatcherWithGet := func(
+		karRunner runner.Runner,
+		getVMI func() (*v1.VirtualMachineInstance, error),
+		watchers ...*watch.FakeWatcher,
+	) chan error {
 		vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
-		vmiInterface.EXPECT().Watch(gomock.Any(), gomock.Any()).Return(fakeWatcher, nil).MinTimes(1)
+		vmiInterface.EXPECT().Get(gomock.Any(), vmInstance, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ metav1.GetOptions) (*v1.VirtualMachineInstance, error) {
+				return getVMI()
+			}).AnyTimes()
+
+		for _, watcher := range watchers {
+			vmiInterface.EXPECT().Watch(gomock.Any(), gomock.Any()).Return(watcher, nil).Times(1)
+		}
+
 		virtClient.EXPECT().VirtualMachineInstance(k8sv1.NamespaceDefault).Return(vmiInterface).AnyTimes()
 		runner.NewAppContext(vmInstance, "")
 
@@ -82,7 +94,26 @@ var _ = Describe("Runner", func() {
 			close(errChan)
 		}()
 
+		return errChan
+	}
+
+	startVMIWatcher := func(karRunner runner.Runner) (*watch.FakeWatcher, chan error) {
+		fakeWatcher := watch.NewFake()
+		errChan := startVMIWatcherWithGet(karRunner, func() (*v1.VirtualMachineInstance, error) {
+			return NewVirtualMachineInstance(vmInstance), nil
+		}, fakeWatcher)
+
 		return fakeWatcher, errChan
+	}
+
+	startReconnectVMIWatcher := func(karRunner runner.Runner) (*watch.FakeWatcher, *watch.FakeWatcher, chan error) {
+		firstWatcher := watch.NewFake()
+		secondWatcher := watch.NewFakeWithChanSize(1, false)
+		errChan := startVMIWatcherWithGet(karRunner, func() (*v1.VirtualMachineInstance, error) {
+			return NewVirtualMachineInstance(vmInstance), nil
+		}, firstWatcher, secondWatcher)
+
+		return firstWatcher, secondWatcher, errChan
 	}
 
 	DescribeTable("create resources", func(shouldSucceed bool, vmTemplate, runnerName, jitConfig string) {
@@ -214,6 +245,96 @@ var _ = Describe("Runner", func() {
 		fakeWatcher.Add(vmi)
 
 		Eventually(errChan, timeout).Should(Receive(MatchError("timeout while waiting for the virtual machine instance")))
+	})
+
+	It("re-establishes the VMI watch when the watch stream closes", func() {
+		const timeout = 3 * time.Second
+
+		firstWatcher, secondWatcher, errChan := startReconnectVMIWatcher(karRunner)
+
+		vmi := NewVirtualMachineInstance(vmInstance)
+		vmi.Status.Phase = v1.Running
+		firstWatcher.Add(vmi)
+		firstWatcher.Stop()
+
+		Consistently(errChan, 100*time.Millisecond).ShouldNot(Receive())
+
+		vmi.Status.Phase = v1.Succeeded
+		secondWatcher.Modify(vmi)
+
+		Eventually(errChan, timeout).Should(Receive(BeNil()))
+	})
+
+	It("re-establishes the VMI watch after the Running+Ready milestone", func() {
+		const timeout = 3 * time.Second
+
+		firstWatcher, secondWatcher, errChan := startReconnectVMIWatcher(karRunner)
+
+		readyVMI := NewVirtualMachineInstanceReady(vmInstance)
+		firstWatcher.Modify(readyVMI)
+		firstWatcher.Stop()
+
+		Consistently(errChan, 100*time.Millisecond).ShouldNot(Receive())
+
+		readyVMI.Status.Phase = v1.Succeeded
+		secondWatcher.Modify(readyVMI)
+
+		Eventually(errChan, timeout).Should(Receive(BeNil()))
+	})
+
+	It("uses the wait timeout as the upper bound for closed watch streams", func() {
+		const waitTimeout = 10 * time.Millisecond
+
+		const timeout = 1 * time.Second
+
+		shortTimeoutRunner := runner.NewRunner(k8sv1.NamespaceDefault, virtClient, waitTimeout)
+		vmiInterface := kubecli.NewMockVirtualMachineInstanceInterface(mockCtrl)
+		vmiInterface.EXPECT().Get(gomock.Any(), vmInstance, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ string, _ metav1.GetOptions) (*v1.VirtualMachineInstance, error) {
+				vmi := NewVirtualMachineInstance(vmInstance)
+				vmi.Status.Phase = v1.Running
+
+				return vmi, nil
+			}).AnyTimes()
+		vmiInterface.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+				fakeWatcher := watch.NewFake()
+				fakeWatcher.Stop()
+
+				return fakeWatcher, nil
+			}).AnyTimes()
+
+		virtClient.EXPECT().VirtualMachineInstance(k8sv1.NamespaceDefault).Return(vmiInterface).AnyTimes()
+		runner.NewAppContext(vmInstance, "")
+
+		errChan := make(chan error, 1)
+		go func() {
+			errChan <- shortTimeoutRunner.WaitForVirtualMachineInstance(context.TODO())
+
+			close(errChan)
+		}()
+
+		Eventually(errChan, timeout).Should(Receive(MatchError("timeout while waiting for the virtual machine instance")))
+	})
+
+	It("fails when the VMI disappears before a watch can be re-established", func() {
+		firstWatcher := watch.NewFake()
+		getCalls := 0
+		errChan := startVMIWatcherWithGet(karRunner, func() (*v1.VirtualMachineInstance, error) {
+			getCalls++
+			if getCalls > 1 {
+				err := k8serrors.NewNotFound(
+					schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"}, vmInstance)
+
+				return nil, err
+			}
+
+			return NewVirtualMachineInstance(vmInstance), nil
+		}, firstWatcher)
+
+		firstWatcher.Stop()
+
+		Eventually(errChan, 3*time.Second).Should(Receive(MatchError(ContainSubstring("failed to get the virtual machine instance"))))
 	})
 })
 


### PR DESCRIPTION
This PR fixes long-running VM job handling when the Kubernetes watch stream closes unexpectedly.

Previously, the runner could exit when the watch channel closed, even though the VMI was still running.
Now the runner treats closed watch streams as recoverable and re-establishes the watch until a true terminal outcome is reached or wait timeout expires.
Fixes - [#78](https://github.com/electrocucaracha/kubevirt-actions-runner/issues/78)

**What Changed**
- Reworked VMI wait flow to support watch re-establishment on stream closure.
- Added a pre-watch VMI refresh step on each loop iteration.
- Re-opened watch using the latest resourceVersion and a field selector scoped to the target VMI.
- Kept wait timeout as the global upper bound for the full wait lifecycle.
- Clarified local variable naming in the wait loop for terminal result readability.
- Updated timeout guide docs and docs index to describe watch stream reconnection behavior.

**Behavior Details**
- VMI phase Succeeded is treated as terminal success.
- VMI phase Failed is treated as terminal failure.
- Closed watch stream is treated as recoverable and triggers reconnect.
- Context cancellation/timeout still exits with timeout error.
- Tests Added/Updated
- Re-establishes watch when watch stream closes.
- Re-establishes watch after Running+Ready milestone.
- Uses wait timeout as upper bound under repeated watch closures.
- Fails with clear error when VMI disappears before watch can be re-established.